### PR TITLE
Refactor: Personalize main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,54 @@
-# AI Product Development Toolkit (Agnostic Ideation Fork)
+# My AI Product Development Toolkit
 
-Welcome to my personal collection of product development prompt templates! This repository is a fork of the excellent [AI Product Development Toolkit](https://github.com/TechNomadCode/AI-Prompt-Library) by TechNomadCode, and I'm grateful for the solid foundation they provided.
+Welcome! This is my personal collection of product development prompt templates, designed to help me think, plan, and create better product documentation from a Product Manager's point of view.
 
-The main idea behind this fork is to make the project as **agnostic as possible**, focusing specifically on the higher-level product ideation and documentation process, independent of any single implementation tool.
+This project started as a fork of the excellent [AI Product Development Toolkit](https://github.com/TechNomadCode/AI-Prompt-Library) by TechNomadCode. I'm grateful for the solid foundation they provided, and I've adapted it to fit my specific workflow.
 
 ## About This Repository
 
-As I use different AI tools, I often find myself designing specific prompts to get desired outputs. This repository is my way of:
+As a Product Manager, I'm always looking for ways to streamline the process of turning a raw idea into a set of clear, actionable documents. I created this toolkit to help me:
 
-*   **Organizing:** Keeping track of prompts that work well.
-*   **Reusing:** Quickly finding and adapting prompts for new tasks.
-*   **Sharing:** Making useful prompts available (primarily for myself, but maybe helpful to others!).
-*   **Learning:** Refining prompts over time and seeing patterns in what works.
+*   **Structure My Thinking:** These prompts guide me through the critical questions needed to define a product.
+*   **Create a Consistent Workflow:** I can move from a high-level idea to a detailed spec in a repeatable way.
+*   **Generate Foundational Documents:** The output gives me the PRDs, UX flows, and MVP plans I need to kick off a project.
+*   **Stay Tool-Agnostic:** The goal is to produce great documentation first. The generated documents can then be used by any team, in any tool, to start building.
 
-## Guided Conversational Approach
+## The Guided Conversational Approach
 
-What makes these prompts unique is their **user-centered, guided conversational design**:
+What I love about these prompts is their **user-centered, guided conversational design**:
 
-*   **Interactive Process:** Rather than one-shot prompting, these templates guide AI models through an iterative conversation with you.
-*   **Structured Questioning:** The AI asks targeted questions focused on specific aspects of your project, building a comprehensive document piece by piece.
-*   **User Confirmation Checkpoints:** The prompts explicitly instruct the AI to verify its understanding and direction with you before moving to new sections or making significant interpretations.
-*   **Contextual Analysis:** Many templates use inputs from previous steps (like a PRD for context plus an MVP concept), instructing the AI to cross-reference information for consistency.
-*   **Adaptive Guidance:** The templates help you think through aspects you might have missed, while allowing you to maintain control over the final direction.
+*   **An Interactive Process:** Instead of trying to get everything in one shot, these templates guide an AI model through an iterative conversation with me.
+*   **Structured Questioning:** The AI asks targeted questions about specific parts of the project, helping me build a comprehensive document piece by piece.
+*   **Built-in Checkpoints:** The prompts instruct the AI to check in with me regularly, making sure its understanding is aligned with my vision before moving on.
+*   **Contextual Analysis:** The workflow is designed so that later steps use the documents from earlier steps (like using a PRD to define an MVP), ensuring consistency.
+*   **Adaptive Guidance:** The prompts help me think through aspects I might have missed, while letting me keep full control over the final direction.
 
-This approach combines the best of both worlds: AI's ability to provide structure and ask clarifying questions, with your subject matter expertise and decision-making authority.
+This approach gives me the best of both worlds: the AI's power to provide structure and ask smart questions, combined with my own subject matter expertise and final say.
 
-## How to Use: From Idea to Specification Workflow
+## My Workflow: From Idea to Specification
 
-This library is designed to be used sequentially to produce a suite of specification documents. My personal workflow with these documents is as follows:
+I use this library sequentially to produce a full suite of specification documents. My typical workflow looks like this:
 
-1.  **Define Product Vision (PRD):** Start with your raw ideas and use the `PRD/Guided-PRD-Creation.md` prompt to generate a structured **Product Requirements Document (PRD)**.
-2.  **Define User Experience (UX):** Use the `UX-User-Flow/Guided-UX-User-Flow.md` prompt, feeding it the PRD, to create detailed **UX Specifications**.
-3.  **Define MVP Concept:** Use the `MVP-Concept/Guided-MVP-Concept-Definition.md` prompt with your PRD (and optionally UX Specs) to define the focused **MVP Concept Description** (scope, hypothesis, features).
-4.  **Plan MVP Development:** Use `MVP/Guided-MVP.md` (or `Ultra-Lean-MVP/...` for speed) with the PRD and MVP Concept to create the **MVP Development Plan** or **Build Spec**.
-5.  **Plan MVP Testing:** Use the `Testing/Guided-Test-Plan.md` prompt with the MVP features (from Step 3 or 4) to outline the **Test Plan**.
-6.  **Generate Implementation Specs:** The generated documents (PRD, MVP, UX, testing) are then processed through a Custom Gemini Gem to generate specs for use with [Github Spec Kit](https://github.com/github/spec-kit).
-7.  **Begin Implementation:** I take the output from the previous step into VS Code (or any editor/agent supported by Github Spec Kit) and begin implementation.
+1.  **Define the Product Vision (PRD):** I start with my raw ideas and use the `PRD/Guided-PRD-Creation.md` prompt to generate a structured **Product Requirements Document (PRD)**.
+2.  **Define the User Experience (UX):** With the PRD in hand, I use the `UX-User-Flow/Guided-UX-User-Flow.md` prompt to create detailed **UX Specifications**.
+3.  **Define the MVP Concept:** Next, I use the `MVP-Concept/Guided-MVP-Concept-Definition.md` prompt with my PRD (and optionally UX Specs) to define a focused **MVP Concept Description**.
+4.  **Plan the MVP Development:** I use `MVP/Guided-MVP.md` (or the `Ultra-Lean-MVP/...` version for speed) with the PRD and MVP Concept to create a detailed **MVP Development Plan**.
+5.  **Plan the Testing:** Finally, I use the `Testing/Guided-Test-Plan.md` prompt with the MVP features to outline a comprehensive **Test Plan**.
+6.  **Hand-off to the Team:** With these documents, I have a solid foundation to bring to my design and engineering teams. They have the clarity they need to start prototyping, designing, and building.
 
 ## Repository Navigation
 
-This repository is organized into topical folders containing specialized prompts:
+This repository is organized into topical folders containing the specialized prompts:
 
 *   **PRD**: Template for creating comprehensive Product Requirements Documents.
 *   **UX-User-Flow**: Template for translating PRDs into detailed UX Specifications.
 *   **MVP-Concept**: Template for defining the focused MVP Concept (scope, hypothesis, features).
 *   **MVP**: Template for developing detailed MVP development plans based on the concept.
-*   **Ultra-Lean-MVP**: Template focused on rapidly defining core MVP build specifications (alternative to detailed MVP planning).
+*   **Ultra-Lean-MVP**: A faster alternative for defining core MVP build specifications.
 *   **Testing**: Template for creating thorough test plans for software quality assurance.
 
 ```
-⚠️ Readme files in each folder contain crucial details – do not ignore them. ⚠️
+⚠️ The readme files in each folder contain crucial details on how to use each specific prompt – don't ignore them! ⚠️
 ```
 
 [PRD](PRD/README.md)
@@ -66,15 +65,15 @@ This repository is organized into topical folders containing specialized prompts
 
 **General Usage Notes:**
 
-*   **Browse:** Navigate to the relevant folder for the step you're on.
-*   **Copy & Adapt:** Copy the prompt text from the `.md` file. **Crucially, replace all placeholders** like `[ <<< PASTE ... HERE >>> ]` or `[example]` with your specific project details and inputs from previous steps.
-*   **Engage:** Paste the adapted prompt into your AI tool. Answer the AI's questions thoughtfully – your responses guide the process.
-*   **Confirm:** Pay attention to the AI's check-in points to ensure the output stays aligned with your vision.
-*   **Iterate:** Continue the conversation until the desired document/plan is drafted.
+*   **Browse:** Head to the folder for the step you're on.
+*   **Copy & Adapt:** Copy the prompt text from the `.md` file. It's crucial to replace all placeholders like `[ <<< PASTE ... HERE >>> ]` or `[example]` with your project details.
+*   **Engage:** Paste your adapted prompt into your AI tool of choice. Answer the AI's questions thoughtfully—your responses are key.
+*   **Confirm:** Keep an eye out for the AI's check-in points to make sure the output is on track.
+*   **Iterate:** Continue the conversation until you have a solid draft of the document you need.
 
 ## Model Compatibility
 
-These prompts were developed with large context window models in mind (like Google Gemini, GPT-4, Claude 3), as they need to maintain conversation context throughout potentially lengthy exchanges, often referencing large input documents (like PRDs or UX Specs). For best results when generating final document drafts, consider using a low temperature setting (0.2-0.5) to encourage factual, focused output.
+These prompts were developed with large context window models in mind (like Google Gemini, GPT-4, Claude 3), as they need to maintain context through long conversations. For best results when generating final document drafts, I've found it helps to use a low temperature setting (0.2-0.5) to get a more factual, focused output.
 
 ## License
 
@@ -82,4 +81,4 @@ You are generally free to use, adapt, and share these prompts. See the `LICENSE`
 
 ## Disclaimer
 
-AI models and their outputs can be unpredictable. These prompts are starting points and may require significant modification to achieve your desired results. Always review and verify AI-generated content, especially for accuracy, bias, or appropriateness. Human oversight, strategic decision-making, and technical validation are critical at every step.
+AI models and their outputs can be unpredictable. These prompts are starting points and will likely require some tweaking to get exactly what you want. Always review and verify AI-generated content. Your own expertise and strategic decision-making are the most important part of the process!


### PR DESCRIPTION
This commit refactors the main README.md file to give it a more personal and casual tone, reflecting the user's perspective as a Product Manager.

Key changes include:
- Rewriting the text to use a first-person ("I", "my") narrative.
- Reframing the repository's purpose around a Product Manager's workflow for creating foundational project documents.
- Generalizing the "How to Use" section by removing specific technical implementation details (Gemini Gem, Github Spec Kit) and replacing them with a more universal description of handing off documents to a team.

This change aligns with the user's goal of making the forked repository feel like their own personal toolkit and not just a copy of the original.